### PR TITLE
Remove the savePermission on model creation.

### DIFF
--- a/index.js
+++ b/index.js
@@ -259,14 +259,6 @@ Session.prototype = {
       credentials: this.credentials
     });
 
-    if (model.permissions) {
-      // So far, Daybed does not handle permissions during model creation
-      // see https://github.com/spiral-project/daybed/pull/230
-      create = create.then(function () {
-        return this.savePermissions(modelId, model.permissions);
-      }.bind(this));
-    }
-
     return create;
   },
 

--- a/test/test.session.js
+++ b/test/test.session.js
@@ -112,19 +112,6 @@ describe('Daybed.Session', function() {
 
     describe('Save models', function() {
 
-        it("should save permissions if specified", function (done) {
-            server.respondWith("PUT", "/v1/models/app:test", '{ "definition": {} }');
-            server.respondWith("PATCH", "/v1/models/app:test/permissions", '{ "userid": ["read_all_records"] }');
-
-            var example = {definition: {}, permissions: {"Everyone": ["+ALL"]}};
-
-            session.saveModel('app:test', example)
-            .then(function (permissions) {
-                assert.deepEqual(permissions['userid'], ['read_all_records']);
-                done();
-            });
-        });
-
         it("should save all specified models", function (done) {
             server.respondWith("GET", "/v1/models", '{ "models": [] }');
             server.respondWith("PUT", "/v1/models/app:mod1", '{ "title": "a", "definition": {} }');


### PR DESCRIPTION
This is not needed anymore since Daybed supports it directly. For more
information, see the bug on the daybed side:
https://github.com/spiral-project/daybed/pull/230

I removed bot the test and the if block since they're not doing much. I don't
believe we need to test anything specific here since the logic is in daybed,
not daybed.js.
