### PR TITLE
Node compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,21 @@ applications.
 [![Build Status](https://travis-ci.org/spiral-project/daybed.js.png?branch=master)](https://travis-ci.org/spiral-project/daybed.js)
 
 
+## Usage
+
+In the browser, just include the source file:
+
+```html
+  <script src="//spiral-project.github.io/daybed.js/build/daybed.js"></script>
+```
+
+In node, just require the package:
+
+```javascript
+  var Daybed = require('daybed.js');
+```
+
+
 ## Rationale
 
 Note that **Daybed** is a REST backend, and does not require any particular library

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,17 +10,19 @@ var deploy = require("gulp-gh-pages");
 
 var opt = {
   outputFolder: "build",
-
   app: {
-    src: ["./index.js", "./ext/utils.js", "./ext/hkdf.js"],
+    src: "./index.js",
     dest: "daybed.js"
   },
+  bundle: {
+    standalone: 'Daybed'
+  }
 };
 
 
 gulp.task("dist", function() {
   return browserify(opt.app.src)
-    .bundle()
+    .bundle(opt.bundle)
     .pipe(source(opt.app.dest))
     .pipe(gulp.dest(opt.outputFolder));
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,6 +22,7 @@ var opt = {
 
 gulp.task("dist", function() {
   return browserify(opt.app.src)
+    .ignore('xmlhttprequest')
     .bundle(opt.bundle)
     .pipe(source(opt.app.dest))
     .pipe(gulp.dest(opt.outputFolder));

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ function _credentials(hawkinfo) {
   var token = typeof(hawkinfo.token) == 'function' ? hawkinfo.token()
                                                    : hawkinfo.token;
 
-  // Derive credentials with hdfk
+  // Derive credentials with hkdf
   if (!credentials && token) {
     deriveHawkCredentials(token, 'sessionToken', 32*2, function (creds) {
       credentials = creds;
@@ -576,5 +576,4 @@ var Daybed = {
   Model: Model
 };
 
-window.Daybed = Daybed;
 module.exports = Daybed;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var Promise = require('promise-polyfill');
 var utils = require('./ext/utils.js');
 var console = require("console");
 var hawk = require('hawk');

--- a/index.js
+++ b/index.js
@@ -1,5 +1,10 @@
 "use strict";
 
+var isNode = (typeof process !== 'undefined' && process.title === 'node');
+if (isNode) {
+    global.XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
+}
+
 var Promise = require('promise-polyfill');
 var utils = require('./ext/utils.js');
 var console = require("console");

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "gulp-uglify": "^0.3.*",
     "browserify": "^4.1.*",
     "vinyl-source-stream": "^0.1.*",
-    "promise-polyfill": "1.1.*"
+    "promise-polyfill": "1.1.*",
+    "xmlhttprequest": "^1.6.*"
   },
   "devDependencies": {
     "mocha": "1.21.*",

--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
     "gulp-gh-pages": "^0.3.*",
     "gulp-uglify": "^0.3.*",
     "browserify": "^4.1.*",
-    "vinyl-source-stream": "^0.1.*"
+    "vinyl-source-stream": "^0.1.*",
+    "promise-polyfill": "1.1.*"
   },
   "devDependencies": {
     "mocha": "1.21.*",
     "chai": "1.9.*",
     "sinon": "1.10.*",
-    "mocha-phantomjs": "3.5.*",
-    "promise-polyfill": "1.1.*"
+    "mocha-phantomjs": "3.5.*"
   }
 }

--- a/test/index.html
+++ b/test/index.html
@@ -7,7 +7,6 @@
     <body>
         <div id="mocha"></div>
 
-        <script src="../node_modules/promise-polyfill/Promise.js"></script>
         <script src="../node_modules/chai/chai.js"></script>
         <script src="../node_modules/mocha/mocha.js"></script>
         <script src="../node_modules/sinon/pkg/sinon.js"></script>

--- a/test/index.html
+++ b/test/index.html
@@ -15,6 +15,7 @@
 
         <script>mocha.setup('bdd')</script>
 
+        <script src="init.js"></script>
         <script src="test.hello.js"></script>
         <script src="test.session.js"></script>
         <script src="test.gettoken.js"></script>

--- a/test/init.js
+++ b/test/init.js
@@ -1,0 +1,10 @@
+var isBrowser = (typeof process === 'undefined' || process.title !== 'node');
+
+if (isBrowser) {
+    assert = chai.assert;
+}
+else {
+    assert = require('chai').assert;
+    sinon = require('sinon');
+    Daybed = require('..');
+}

--- a/test/test.gettoken.js
+++ b/test/test.gettoken.js
@@ -1,6 +1,3 @@
-var assert = chai.assert;
-
-
 describe('Daybed.getToken', function() {
 
     var server;

--- a/test/test.hello.js
+++ b/test/test.hello.js
@@ -1,5 +1,3 @@
-var assert = chai.assert;
-
 describe('Hello page', function() {
     var server;
     var sandbox;

--- a/test/test.model.js
+++ b/test/test.model.js
@@ -1,6 +1,3 @@
-var assert = chai.assert;
-
-
 describe('Daybed.Model', function() {
 
     var server;

--- a/test/test.session.js
+++ b/test/test.session.js
@@ -1,6 +1,3 @@
-var assert = chai.assert;
-
-
 describe('Daybed.startSession', function() {
 
     var server;

--- a/test/test.sync.js
+++ b/test/test.sync.js
@@ -1,6 +1,3 @@
-var assert = chai.assert;
-
-
 describe('Records synchronization', function() {
 
     var server;


### PR DESCRIPTION
- [x] get rid of window export
- [x] use lib for Promise object
- [x] use lib for XMLHttpRequest object ([xhr](https://github.com/Raynos/xhr) ?)
- [x] update README

``` diff
 var utils = require('./ext/utils.js');
 var console = require("console");
+var Promise = require("bluebird");
+var XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
 var hawk = require('hawk');
 var deriveHawkCredentials = require('./ext/hkdf.js').deriveHawkCredentials;
```
